### PR TITLE
Fix typos in abstract of software dev wg paper

### DIFF
--- a/CWP/papers/HSF-CWP-2017-13_soft-dev/latex/cwp-wg-software-development.tex
+++ b/CWP/papers/HSF-CWP-2017-13_soft-dev/latex/cwp-wg-software-development.tex
@@ -18,7 +18,7 @@
 %\usepackage{lineno}  % for line numbering during review
 %\linenumbers
 
-\abstract{The High Energy Phyiscs community has developed and needs to maintain
+\abstract{The High Energy Physics community has developed and needs to maintain
 many tens of millions of lines of code and to integrate effectively the
 work of thousands of developers across large collaborations. 
 Software needs to be built, validated, and deployed across hundreds of
@@ -26,10 +26,10 @@ sites. Software also has a lifetime of many years, frequently beyond that
 of the original developer, it must be developed with sustainability in
 mind. Adequate recognition of software development as a critical task in the HEP
 community needs to be fostered and an appropriate publication and citation
-strategy needs to be developed. As part of the HEP Softare Foundation's
+strategy needs to be developed. As part of the HEP Software Foundation's
 Community White Paper process a working group on Software Development,
 Deployment and Validation was formed to examine all of these
-issues, identify best practice and to formulare recommendations for the next
+issues, identify best practice and to formulate recommendations for the next
 decade. Its report is presented here.}
 
 \begin{document}


### PR DESCRIPTION
When checking the arXiv page today, I noticed some typos in the abstract for the [Software Development, Deployment and Validation Working Group Paper](https://arxiv.org/abs/1712.07959). 

I coordinated with @graeme-a-stewart over email today about fixing them, so here they are. Unfortunately, I can't assign reviewers due to access restrictions on the repo, but I think it will get to the right person since Graeme is tagged.