### PR TITLE
CWP Training: Adding author/institute, and formatting

### DIFF
--- a/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
+++ b/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
@@ -40,8 +40,9 @@ Training, Staffing and Careers}
 \author[7]{Sudhir Malik,}
 \author[8]{Dario Menasce,}
 \author[6]{Mark Neubauer,}
-\author[9,a]{Albert Puig}
-\author[1]{and Graeme Stewart}
+\author[9,a]{Albert Puig,}
+\author[1]{Graeme Stewart,}
+\author[10]{and Christopher Tunnell}
 
 \affiliation[1]{CERN, Geneva, Switzerland}
 \affiliation[2]{Department of Physics and Astronomy, University of Pittsburgh, Pittsburgh, PA, USA}
@@ -52,6 +53,7 @@ Training, Staffing and Careers}
 \affiliation[7]{University of Puerto Rico, Mayaguez, PR, USA}
 \affiliation[8]{INFN Sezione di Milano-Bicocca, Italy}
 \affiliation[9]{Physik-Institut, Universität Zürich, Zürich, Switzerland}
+\affiliation[10]{University of Chicago, Chicago, IL, USA}
 \affiliation[a]{Supported by SNF under contract 168169.}
 
 \maketitle


### PR DESCRIPTION
The following changes were made just to the author list:
* I added myself "Christopher Tunnell" and my institute "University of Chicago".
* Furthermore, there were no commas after a few other names toward the end that I added for consistency
* The "and" I assume happens with the last name in alphabetical order.  Since "Tunnell" is after "Stewart", I moved the 'and' to my name as the last alphabetically.