### PR TITLE
Training last points

### DIFF
--- a/CWP/papers/HSF-CWP-2017-01_roadmap/latex/cwp.bib
+++ b/CWP/papers/HSF-CWP-2017-01_roadmap/latex/cwp.bib
@@ -135,6 +135,21 @@
     url = {https://www.skatelescope.org/}
 }
 
+@online{PomodoroTechnique,
+	title = {Pomodoro Technique},
+	url = {https://en.wikipedia.org/wiki/Pomodoro_Technique}
+}
+
+@online{Docker,
+	title = {Docker Containers},
+	url = {https://www.docker.com/}
+}
+
+@online{JupyterHub,
+	title = {Jupyter Hub},
+	url = {https://jupyterhub.readthedocs.io/en/stable/}
+}
+
 @article{ALLISON2016186,
 title = "Recent developments in Geant4",
 journal = "Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment",

--- a/CWP/papers/HSF-CWP-2017-01_roadmap/latex/cwp.bib
+++ b/CWP/papers/HSF-CWP-2017-01_roadmap/latex/cwp.bib
@@ -150,6 +150,11 @@
 	url = {https://jupyterhub.readthedocs.io/en/stable/}
 }
 
+@online{HSFTrainingWG,
+	title = {HEP Software Foundation Working Group},
+	url = {https://hepsoftwarefoundation.org/activities/training.html}
+}
+
 @article{ALLISON2016186,
 title = "Recent developments in Geant4",
 journal = "Nuclear Instruments and Methods in Physics Research Section A: Accelerators, Spectrometers, Detectors and Associated Equipment",

--- a/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
+++ b/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
@@ -360,8 +360,8 @@ student competence. Special care must be given to setup
 a training structure that can cope with both beginners and advanced students.
 This may rest on a low granularity subdivision of independant topics.
 The IN2P3 authors try to restrict their tutorials to 20 minutes
-of material, as inspired by the Pomodoro technique, so that one can easily jump
-and compose one's own ``menu''. However, it turns out to be tricky to keep such
+of material, as inspired by the Pomodoro technique\cite{PomodoroTechnique}, so
+that one can easily jump and compose one's own ``menu''. However, it turns out to be tricky to keep such
 small tutorials really independant and meaningful when they can be selected at
 will.
 
@@ -369,9 +369,10 @@ All trainers have also faced the tremendous loss of time
 in software installation for any practical exercises as many students have
 not managed to prepare their machines in advance.
 Here containers may bring real
-progress, provided that everyone has at least Docker installed on their machine.
-JupyterHub, also, is a technology which enable training session with
-no need for installation (but with a need for network).
+progress, provided that everyone has at least Docker\cite{Docker} installed on
+their machine.
+JupyterHub\cite{JupyterHub}, also, is a technology which enable training session
+with no need for installation (but with a need for network).
 
 %____________________________________________________________________
 \subsection{Initiatives for future training programmes\label{sec:initiatives}} 
@@ -679,7 +680,7 @@ The HEP community by and large acknowledges and recognizes the great importance
 of training in the field of scientific computing. This activity should encompass
 several types of {\it students}, from undergraduates, to young researchers, up
 to senior physicists, all of them in need of an appropriately designed training
-path in order to be proficent in their scientific endevours.
+path in order to be proficent in their scientific endeavours.
 
 We have identified a certain number of problems that need to be overcome in
 setting up an appropriate training programme:
@@ -691,7 +692,8 @@ setting up an appropriate training programme:
     corresponding Funding Agencies
 \end{itemize}
 
-For each of these points we provide an overview of the current situation and possible proposals to build a roadmap.
+For each of these points we have provided an overview of the current situation
+and made proposals to improve the situation in HEP.
 
 %% GS Comment - this section is incomplete. FIXME.
 

--- a/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
+++ b/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
@@ -359,7 +359,7 @@ Another challenge is the wide heterogeneity in
 student competence. Special care must be given to setup
 a training structure that can cope with both beginners and advanced students.
 This may rest on a low granularity subdivision of independant topics.
-The IN2P3 authors try to restrict their tutorials to 20 minutes
+The IN2P3 authors try to restrict their tutorials to 25 minutes
 of material, as inspired by the Pomodoro technique\cite{PomodoroTechnique}, so
 that one can easily jump and compose one's own ``menu''. However, it turns out to be tricky to keep such
 small tutorials really independant and meaningful when they can be selected at

--- a/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
+++ b/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
@@ -139,7 +139,7 @@ The main requirements and challenges to be faced were identified as follows:
     \item to properly assign credit to software development as a scientific 
     discipline, including training activities,
     \item to establish policies for the hiring and long-term retention of researchers 
-    specialising computing,
+    specialising in computing,
     \item to address the gap in formal software training that is not always 
     given by universities as part of a physicist's education.
 \end{itemize}
@@ -176,77 +176,58 @@ the National Science Foundation (NSF) \cite{NSF1,NSF2}.
 A key goal is to find incentives that will encourage 
 increasing numbers of people to dedicate their time and effort to train their
 colleagues.
-
 To be effective, the training must be done by people who work at the cutting
-edge of the technology, who in many cases are found among the youngest
+edge of the technology and who in many cases are found among the youngest
 researchers. These are also the very same people who are most in need of
-officially recognized credits for the advancement of their careers. Currently
+officially recognized credits for the advancement of their careers. Currently,
 visibility and recognition is given mainly to those working on data analysis
 projects, rather than to the development and support of the underlying
 software. One solution to this problem would be the establishment of specific
 career paths for researchers specialising in scientific software development. 
-%% GS Comment - is this actually ``motivation'' - it seems more like a solution
-% See suggested title change for this section...
 However, the practical 
 implementation of such an approach is extremely challenging, as there are a wide range of
 institutions involved that belong to different countries with their own
 policies, priorities, and funding strategies. 
 
 Broadly speaking, two scientific profiles of researchers could be
-envisaged; a physicst could make a detailed plan of what they need, expressed 
+envisaged. A physicst could make a detailed plan of what they need, expressed 
 in a tidy requirements document, and a computer scientist could use this document 
 to provide the required solution. This is how the software development process 
 typically works in the software industry. However, in HEP requirements are rapidly
 changing, forcing developers and physicsts to interact closely during the entire
-process of software development; this works smoothly only when both communities have the
-same goals and speak the same language, hence the need for physicists with a good
+process of software development. This works smoothly only when both communities
+have the same goals and speak the same language, hence the need for physicists with a good
 knowledge of computer science.
 
-The first possible career would be the path of a \emph{physicist researcher with
-computing science specialisation}, in some places corresponding to the role of a
-physicist-programmer. It would be conceptually different to that of a
-\emph{computer scientist}: the two have different goals, seek different paths to
-the solution of their problems, and usually do not even adopt the same language in
-expressing problems and solutions. Such a role would have an active role in
-physics analysis, and so meet many of the traditional metrics for an academic
-career path.
+The first possible career path would be that of a \emph{physicist with computing
+science specialisation}, also known as a physicist-programmer in some
+communities. (It would be conceptually different to that of a \emph{computer
+scientist} as the two have different goals, seek different paths to the solution
+of their problems, and usually do not even share the same language.) Such people
+would have an active role in physics analysis, and so meet many of the criteria
+needed for an academic career path.
 
-The second would be the path of a domain-specific \emph{researcher software
+The second would be the path of a domain-specific \emph{software
 engineer}. Such a person has the primary role of developing software and finding
-software solutions, but with a large domain-specific knowledge to both
-understand the use cases and clients, but also of the available solutions.  Such
-posts are almost impossible to develop in the current academic frameworks; but
-while RSEs are understood by many funding agencies and universities as a
-technical post, they are seen as available for short-term engagements with a
-researcher community, delivering a quick fix or a refactoring and then moving
-on. This does not deliver the domain specific expertise required.
+software solutions, but with a large domain-specific knowledge to
+understand relevant use cases and the available solutions. 
+Such posts are almost impossible to establish in current academic
+institutions; rather being seen by many funding agencies and
+universities as short term technical positions. This does not allow domain
+specific expertise to be aquired or retained in our field.
 
 Both career paths suffer in academic terms from few or poorly cited
 publications, few opportunities to win grants in their own right and little
 opportunity for impact with commerce and wider society. These three failings
-make an academic appointment challenging or disfavoured compared to other
+make an academic appointment challenging or disfavoured as compared to other
 applicants. However, there are measures that can be taken to address all three
-weaknesses.
-%% GS Comment - This is an odd place to end a section. What are these measures?
-% Where do we list them? Even a forward reference would help.
-
-% This makes the development of specific solutions even more difficult and
-% cumbersome.
-
-%Finally, the career of these two figures follows slightly different paths, with different requirements. 
-%____________________________________________________________________
-%\subsection{Existing Training efforts  \textcolor{pink}{is this needed?....}}
-% why not, shows what is done already
-
+weaknesses, which we expand on in the remainder of this document.
 
 %____________________________________________________________________
 %____________________________________________________________________
 \section{Training needs of the community}
 
-% DOES THIS SECTION ANSWER THE FOLLOWING: 
-% - Different levels of training are required 
-
-The HEP user community consists of a set of users with diverse software
+The HEP community consists of people with diverse software
 experience, interests, and time availablity to learn new techniques.  Any
 training programme must take into account the variation in target audiences. For
 example, an undergraduate doing a summer research project has different needs
@@ -254,25 +235,22 @@ and skills than their professor.
 
 \subsection{Classification of trainees}
 
-For purposes of training, it is useful to think of all our user community as
-\emph{students}. More specifically, we can broadly identify four different sets
-of students, classified by experience level:
+For purposes of training we can broadly identify classify four
+different experience levels:
 
 \begin{itemize}
-   \item \emph{Beginners}: New collaborators with no knowledge of the 
-   tools or techniques they are expected to use. These might be undergraduates, 
-   but they could also be senior researchers who have not yet, or not recently, 
-   engaged in software analysis. These are people in need of some kind of formal 
-   training in modern computing techniques (basically compiled and scripting 
+   \item \emph{Beginner}: New collaborators with no knowledge of the 
+   tools or techniques they are expected to use. These are people in need of some kind of formal 
+   training in modern computing techniques, such as compiled and scripting 
    languages, together with operating system basics such as filesystems, version 
-   control, and command-line shells).
-   \item \emph{Intermediate level analysts}: people with some experience in 
-   either analysis concepts and/or tools, but  looking to supplement their 
+   control, and command-line shells.
+   \item \emph{Intermediate}: People with some experience in 
+   concepts and tools, but looking to supplement their 
    experience with more recent and modern approaches. 
-   \item \emph{Advanced level analysts}: experts who have mastered current 
+   \item \emph{Advanced}: Experts who have mastered current 
    technologies and implementations and who want to stay up-to-date with 
    new advanced developments.
-   \item \emph{Software developers}: HEP scientists in charge of software 
+   \item \emph{Software Specialists}: HEP scientists in charge of software 
    development in areas not limited only to analysis, such as DAQ systems, 
    computing infrastructure, databases, pattern recongition, and complete 
    frameworks.
@@ -295,16 +273,14 @@ of any training programme.
 \subsection{Knowledge that needs to be transferred}
 
 At all stages of software and computing training, we should take care to
-encourage \emph{Good Practices Across the Community}, such as error
+encourage \emph{good practices across the community}, such as ensuring error
 checking, modularity of code design, version control, writing tests, etc. All
-the key concepts addressed in the training should not be specific to a
-particular experiment or field of application, but general enough to be useful
-to the whole HEP community and beyond. In this section, we present a
-list of specific concepts that need to be taught, in
+the key concepts addressed in training should not be specific to a particular
+experiment or field of application, but general enough to be useful to the whole
+HEP community and beyond. A number of specific concepts need to be taught, in
 order to guarantee the basic level of competence needed to write efficient code
-for the different tasks performed in HEP experiments.
- 
-Essential knowledge that needs to be transferred includes basic
+for the various tasks that need to be performed in HEP experiments.
+These include
 programming concepts, data structures, basics of code design, error checking,
 code management tools, validation and debugging tools. More advanced topics
 include modularity of code design, advanced data structures, evaluation metrics,
@@ -318,52 +294,46 @@ listed in Appendix \ref{appendix-a---training-topics-of-interest}.
 
 % ____________________________________________________________________
 % ____________________________________________________________________
-\section{Implementation Roadmap}
-The implementation of training should target multiple training formats and
-knowledge transfer, such as videos, wikis, lectures, jupyter notebooks and
-advanced visualizations, etc.
-People who learn in non-conventional ways should not be excluded from the
-opportunity to learn. 
-%% GS Comment - I'm not really sure what that previous sentence is supposed to
-% mean.
-Since there are different stages of knowledge transfer,
-programmes should be developed that encourage experts to share knowledge. Issues
-considered in this section include global training initiatives, strategies for
-leveraging existing forums, and training tool development.
+\section{Advancing Training in HEP}
+
+The implementation of training should employ different training formats, such as
+videos, wikis, lectures, jupyter notebooks and advanced visualizations, etc.,
+so that people can learn in a familiar and effective manner and in such a way
+that experts are encouraged to share their knowledge.
 
 An important point to consider is the difficulty, often experienced in the past,
-in developing large software programs across different experiment communities.
+in developing large software programs across different experiment
+collaborations.
 While there already are experiment-specific training efforts in place, there are
-many needs that are in common between experiments. Therefore, we should probably
-strive to extract the common knowledge and build a common training programme. This
+many needs that are in common. Establishing a common training programme could
+help facilitate the sharing of exprience amongst different experiments. This
 would reduce duplication of efforts and enable growth of a shared training
-culture by accumulating and sharing expertise across different experiments.
-To realise this goal, a possibility could be the institution of a {\em
-federation} of existing training initiatives, a very lightwheight umbrella just
+culture by accumulating and sharing expertise.
+To realise this goal, a possibility could be the creation of a 
+\emph{federation} of training initiatives,
 aimed at improving the efficiency and cost-effectivness of this important
 activity. An appropriate incentive programme to reward those who train the community 
 might help to facilitate the goals of such an initiative.
 
 When trying to exchange training materials within a group the first problem is
 to convince authors to contribute their work. This issue
-can be alleviated with cautious intellectual property clauses. Another
-problem is that trainers do not like to reuse given material as-is. They usually
-want to refactor it, building their own training story.
-This makes it difficult to have everyone agree on common material.
+can be alleviated by addressing the correct assignment of intellectual property.
+Another problem is that trainers do not like to reuse given material as-is. They usually
+want to refactor it, building their own training history.
+This makes it difficult to have everyone agree on common approaches.
 It is even challenging to agree to host material in the same
 centralized place. A way to overcome this could be to settle for a centralized
 catalog, with each author being free to host their material in their location
 of choice.
 
-Another challenge is the wide heterogeneity in
-student competence. Special care must be given to setup
-a training structure that can cope with both beginners and advanced students.
-This may rest on a low granularity subdivision of independant topics.
-The IN2P3 authors try to restrict their tutorials to 25 minutes
-of material, as inspired by the Pomodoro technique\cite{PomodoroTechnique}, so
-that one can easily jump and compose one's own ``menu''. However, it turns out to be tricky to keep such
-small tutorials really independant and meaningful when they can be selected at
-will.
+Another challenge is the wide range of student competence. Special care must be
+given to setup a training structure that can manage both introductory and
+advanced material. This may be addressed by organising course material as a
+large number of independant topics. The IN2P3 authors try to restrict their
+tutorials to 25 minutes, as inspired by the Pomodoro
+technique\cite{PomodoroTechnique}, so that one can easily jump and compose one's
+own curriculum. However, it turns out to be tricky to keep such small tutorials
+really independant and meaningful when they can be selected at will.
 
 All trainers have also faced the tremendous loss of time
 in software installation for any practical exercises as many students have
@@ -371,21 +341,21 @@ not managed to prepare their machines in advance.
 Here containers may bring real
 progress, provided that everyone has at least Docker\cite{Docker} installed on
 their machine.
-JupyterHub\cite{JupyterHub}, also, is a technology which enable training session
-with no need for installation (but with a need for network).
+JupyterHub\cite{JupyterHub} is a technology which supports training sessions
+without the need for specilaist installations.
 
 %____________________________________________________________________
-\subsection{Initiatives for future training programmes\label{sec:initiatives}} 
+\subsection{Initiatives for Future Training Programmes\label{sec:initiatives}} 
 
-Some methods that can be used for global training include Massive Online Open
-Courses (MOOCs), hands-on workshops, online knowledge bases, expert trainer volunteer
+Some methods that can be used for location independent training include Massive
+Online Open Courses (MOOCs), hands-on workshops, online knowledge bases, expert trainer volunteer
 networks, and web-based training approaches.
 
 MOOCs can be used to develop an open-source set of
 tutorials and tools. Existing online courses such as Udacity~\cite{Udacity} and 
 Coursera~\cite{Coursera} can be
-evaluated and recommended to the community. A novel approach such as WikiToLearn~\cite{WikiToLearn}
-could also be explored to assess potential benefits (as has already been attempted
+evaluated and exploited by the community. A novel approach such as
+WikiToLearn~\cite{WikiToLearn} could also be explored to assess potential benefits (as has already been attempted
 in the context of the GridKa School of Computing~\cite{GridKa}, see below).
 
 Experiment-specific and global knowledge bases can be established with
@@ -397,8 +367,8 @@ of great help.
 Question-and-answer websites such as Stack Overflow~\cite{Stackoverflow} for HEP are also a very
 useful resource for common problems and questions. This approach has already
 been considered by HSF start-up members, and turned out to be difficult to
-pursue for a number of reasons, but in the future, boundary conditions might
-change, making this approach viable.
+pursue due to the lack of a critical mass needed by Stack Overflow, but in the
+future, boundary conditions might change, making this approach viable.
 
 Hands-on workshops are an invaluable part of learning how to apply theoretical
 concepts in practice. Identifying which of the current workshops are productive
@@ -416,41 +386,26 @@ substantial time to training and tutoring, they must be assured that such an
 effort would be properly recognised in an official way. Such kind of recognition
 is not currently implemented, at least not in a standardized or official way. A
 possible structure for such a network could be the establishment of a 
-{\em federation} of existing schools.
+{\em federation} of existing schools, as discussed in \S\ref{sec:ehcurtrainprog}.
 
-It should be considered that some professors, who act as graduate student
-advisors, might need to be encouraged to make sure their students are properly
-trained. Sometimes, students are instead pushed to learn the bare minimum to get
-the work done, at the expense of a broader training/education curriculum that
-could actually yield improved results further down the line. One incentive
-would be to provide training programmes that also count as course credit, perhaps
-as an elective. This model is already in limited use with some online
-solutions~\cite{TrainingProgram}, but this is not universal.
-Discussions should be started with collaborators at higher education
-institutions to see what the roadblocks or opportunities would be for these
-training sessions to serve double duty.
-It should also be considered that not all students will end their career in
-research or academia: their contribution to the research activity, as students,
-should therefore also provide them knowledge, know-how, and skills considered a
-valuable asset by industry, in order to increase their chances of a career
-outside research.
+\subsection{Web Based Training}
 
 Difficulties that have emerged in the past with respect to implementing training
 courses are the lack of funding and the lack of available time by experts in the
-field. People with enough expertise or insight usually don't have
-time to devote to prolonged periods of student training, and, even when they can
-find time, the cost of setting up a training course in an effective way is often
-beyond what's made available by funding agencies (funds for travel, hosting,
-setting up a room with a computing infrastructure to allow interactive hands-on
-session, etc.) A possible solution is a completely different approach to
-training (but complementary to the already existing and successful classical
-efforts such as the CERN School of Computing's Bertinoro and KIT ones): instead
-of directly teaching to students, trainees could make use of a web-based
-platform to provide training materials to students. This complementary approach
-has several advantages over traditional ones:
+field. People with enough expertise or insight usually don't have time to devote
+to prolonged periods of student training, and, even when they can find time, the
+cost of setting up a training course in an effective way is often beyond what is
+made available by funding agencies (funds for travel, hosting, setting up a room
+with a computing infrastructure to allow interactive hands-on session, etc.) A
+possible solution is a completely different approach to training, using a
+web-based platform to provide training materials to students. This would be
+complementary to the already existing and successful efforts such as the CERN
+School of Computing's Bertinoro and KIT ones. 
+
+The web based approach has several advantages over traditional ones:
 \begin{itemize}
    \item Tutors can add material to the web site at a very slow pace (whenever
-   they find time to do it, one slide a week or a chapter a day) 
+   they find time to do it, one slide a week or a chapter a day) .
    \item Their material, available public on a web-site, can be further expanded
    by collaborators (also at their own pace) or, even better and more productively, by students
    who decide to contribute new additions, examples, exercises etc. Such a
@@ -462,10 +417,10 @@ has several advantages over traditional ones:
    training material needs to be moderated and validated with appropriate
    policies.
    \item If complemented by the availability of remote virtual machines
-   (possibly through a browser), students could have access to examples and
+   (possibly via a browser), students could have access to examples and
    exercises that are already embedded in their own natural environment: all the
-   necessary tools/libraries needed to implement the exercise will be already
-   available in the virtual machine (possibly a Docker container). With just a
+   necessary tools and libraries needed to implement the exercise will be
+   already available in the virtual machine (possibly a Docker container). With just a
    web browser, students could run complex examples from home, taking advantage
    of a remote facility that provides some storage and computing power.
    Important here is the concept of ``environment'': a Docker container could be
@@ -513,7 +468,7 @@ An interesting exercise in this context has recently been made by colleagues of
 the GridKa School of computing: the material from this year (2017) has been made
 publicly available on WTL~\cite{WikiToLearnGridka}.
 This constitutes an interesting example of what can be accomplished using this
-platform; it is just a first example of what's possible, but an inspiring one.
+platform; it is just a first example of what is possible, but an inspiring one.
 
 Another example of web-based platform is a collection of online tutorials
 (mostly written in French) hosted on the Gitlab IN2P3
@@ -531,15 +486,10 @@ complementary approaches to training, such as schools and dedicated web-site
 courses, could be of mutual benefit, in other words how to make them efficiently cooperate in the
 development of a complete training program.
 
-  % \item Question-and-answer web sites such as Stack Overflow 
-   %(https://en.wikipedia.org/wiki/Stack_Overflow) 
-   %/ Stack Exchange are very useful. 
-   %(https://en.wikipedia.org/wiki/Stack_Exchange)
-  % \item An expert/tutor volunteer network (office hours style) can be established.
-   %\item Investing in periodic in-person, hands-on workshops can be continued.
 
 %____________________________________________________________________
-\subsection{Leveraging existing forums}
+\subsection{Enhancing Current Training Programmes}
+\label{sec:ehcurtrainprog}
 
 To achieve our goals for training the community, we can take advantage of
 existing training forums. Resources such as conferences, workshops, and schools
@@ -572,10 +522,6 @@ Bertinoro~\cite{Bertinoro},
 GridKa~\cite{GridKa}, and
 CODAS-HEP~\cite{CODAS-HEP} Schools of Computing.
 
-% Anecdotally, these are viewed as a great success by the CMS community in
-% preparing new collaborators and might serve as a model for future efforts in
-% ML training.
-
 Over the past decade, MOOCs have been developed by universities and private organizations. 
 They have been well received by industry and academia.
 In addition, they provide a lot of flexibility in terms of cost and use of time; 
@@ -591,7 +537,7 @@ right offering for the knowledge needed to work on a specific experiment. We
 can pick and choose modules to tailor an appropriate roadmap of skills to learn.
 More difficult will be to assemble specific training material not already
 avaible elsewhere in an efficient and organized way, since this requires
-adequate organization, volounteers and a suitable infrastructure.
+adequate organization, volunteers and a suitable infrastructure.
 
 Several industry conferences already exist that bring together those in academia
 and industry who are at the cutting edge of these techniques. Conferences such
@@ -618,6 +564,23 @@ using Python tools.
 
 %____________________________________________________________________
 \subsection{Resources and Incentives}
+
+It should be considered that some graduate student
+advisors, might need to be encouraged to make sure their students are properly
+trained. Sometimes, students are instead pushed to learn the bare minimum to get
+the work done, at the expense of a broader training/education curriculum that
+could actually yield improved results further down the line. One incentive
+would be to provide training programmes that also count as course credit, perhaps
+as an elective. This model is already in limited use with some online
+solutions~\cite{TrainingProgram}, but this is not universal.
+Discussions should be started with collaborators at higher education
+institutions to see what the roadblocks or opportunities would be for these
+training sessions to serve double duty.
+It should also be considered that not all students will end their career in
+research or academia: their contribution to the research activity, as students,
+should therefore also provide them knowledge, know-how, and skills considered a
+valuable asset by industry, in order to increase their chances of a career
+outside research.
 
 Training is something that a large cross-section of the community
 understands to be important, but finding time and effort to contribute to this
@@ -678,8 +641,8 @@ Usage.
 
 The HEP community by and large acknowledges and recognizes the great importance
 of training in the field of scientific computing. This activity should encompass
-several types of {\it students}, from undergraduates, to young researchers, up
-to senior physicists, all of them in need of an appropriately designed training
+several types of \emph{students}, from undergraduates, to young researchers,
+up to senior physicists, all of them in need of an appropriately designed training
 path in order to be proficent in their scientific endeavours.
 
 We have identified a certain number of problems that need to be overcome in
@@ -693,9 +656,9 @@ setting up an appropriate training programme:
 \end{itemize}
 
 For each of these points we have provided an overview of the current situation
-and made proposals to improve the situation in HEP.
-
-%% GS Comment - this section is incomplete. FIXME.
+and made proposals to improve the situation in HEP. The ideas presented need to
+be developed further and concrete actions in the community need to be
+implemented, which we will undertake in the HSF Training Working Group\cite{HSFTrainingWG}.
 
 
 \newpage


### PR DESCRIPTION
Commented by John and Graeme make the arguments more concise.
    
Reorganise the material in Sec 4 to present things in a more
coherent way, organised by topic. Reduce duplication of points
in places.
    
Remove "Roadmap" as a section 4 title as this is not
really what's presented. Point to continuing work in the
auspices of the HSF Training WG in the conclusion.

Many small corrections and a few more references added.