### PR TITLE
Add new authors to the Training paper

### DIFF
--- a/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
+++ b/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
@@ -44,27 +44,34 @@ Training, Staffing and Careers}
 \author[1]{Dario Berzano,}
 \author[2]{Riccardo Maria Bianchi,}
 \author[3]{Peter Elmer,}
+\author[4]{Sergei V. Glayzer}
 \author[1]{John Harvey,}
-\author[4]{Roger Jones,}
-\author[5]{Michel Jouvin,}
-\author[6]{Daniel S. Katz,}
-\author[7]{Sudhir Malik,}
-\author[8]{Dario Menasce,}
-\author[6]{Mark Neubauer,}
-\author[9,a]{Albert Puig,}
+\author[5]{Roger Jones,}
+\author[6]{Michel Jouvin,}
+\author[7]{Daniel S. Katz,}
+\author[8]{Sudhir Malik,}
+\author[9]{Dario Menasce,}
+\author[7]{Mark Neubauer,}
+\author[10]{Fernanda Psihas}
+\author[11,a]{Albert Puig,}
 \author[1]{Graeme A. Stewart,}
-\author[10]{and Christopher Tunnell}
+\author[12]{Christopher Tunnell,}
+\author[10]{Justin A. Vasel,}
+\author[4]{and Sean-Jiun Wang}
 
 \affiliation[1]{CERN, Geneva, Switzerland}
 \affiliation[2]{Department of Physics and Astronomy, University of Pittsburgh, Pittsburgh, PA, USA}
 \affiliation[3]{Princeton University, Princeton, NJ, USA}
-\affiliation[4]{Lancaster University, Lancaster, UK}
-\affiliation[5]{LAL, Université Paris-Sud and CNRS/IN2P3, Orsay, France}
-\affiliation[6]{University of Illinois Urbana-Champaign, Urbana, IL, USA}
-\affiliation[7]{University of Puerto Rico, Mayaguez, PR, USA}
-\affiliation[8]{INFN Sezione di Milano-Bicocca, Italy}
-\affiliation[9]{Physik-Institut, Universität Zürich, Zürich, Switzerland}
-\affiliation[10]{University of Chicago, Chicago, IL, USA}
+\affiliation[4]{University of Florida, Gainesville, FL, USA}
+\affiliation[5]{Lancaster University, Lancaster, UK}
+\affiliation[6]{LAL, Université Paris-Sud and CNRS/IN2P3, Orsay, France}
+\affiliation[7]{University of Illinois Urbana-Champaign, Urbana, IL, USA}
+\affiliation[8]{University of Puerto Rico, Mayaguez, PR, USA}
+\affiliation[9]{INFN Sezione di Milano-Bicocca, Italy}
+\affiliation[10]{Department of Physics, Indiana University, Bloomington, IN,
+USA}
+\affiliation[11]{Physik-Institut, Universität Zürich, Zürich, Switzerland}
+\affiliation[12]{University of Chicago, Chicago, IL, USA}
 \affiliation[a]{Supported by SNF under contract 168169.}
 
 \maketitle

--- a/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
+++ b/CWP/papers/HSF-CWP-2017-02_training/latex/cwp-wg-training-careers.tex
@@ -44,7 +44,7 @@ Training, Staffing and Careers}
 \author[1]{Dario Berzano,}
 \author[2]{Riccardo Maria Bianchi,}
 \author[3]{Peter Elmer,}
-\author[4]{Sergei V. Glayzer}
+\author[4]{Sergei V. Gleyzer}
 \author[1]{John Harvey,}
 \author[5]{Roger Jones,}
 \author[6]{Michel Jouvin,}


### PR DESCRIPTION
Adding authors from the original version of the paper spawned from the ML white paper